### PR TITLE
Add SignedSale contract

### DIFF
--- a/contracts/exchange/EndemicExchange.sol
+++ b/contracts/exchange/EndemicExchange.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.18;
 
 import "./mixins/auction/EndemicAuction.sol";
 import "./mixins/EndemicOffer.sol";
-import "./mixins/EndemicPrivateSale.sol";
+import "./mixins/EndemicSignedSale.sol";
 
-contract EndemicExchange is EndemicAuction, EndemicOffer, EndemicPrivateSale {
+contract EndemicExchange is EndemicAuction, EndemicOffer, EndemicSignedSale {
     /**
      * @notice Initialized Endemic exchange contract
      * @dev Only called once
@@ -21,7 +21,7 @@ contract EndemicExchange is EndemicAuction, EndemicOffer, EndemicPrivateSale {
         __Context_init_unchained();
         __Ownable_init_unchained();
 
-        __EndemicPrivateSale___init_unchained();
+        __EndemicSignedSale___init_unchained();
 
         _updateDistributorConfiguration(_feeRecipientAddress);
         _updateExchangeConfiguration(_royaltiesProvider, _paymentManager);

--- a/contracts/exchange/mixins/EndemicSignedSale.sol
+++ b/contracts/exchange/mixins/EndemicSignedSale.sol
@@ -122,13 +122,16 @@ abstract contract EndemicSignedSale is
             revert InvalidSignature();
         }
 
+        signedSaleInvalidated[nftContract][tokenId][seller][address(0)][price][
+            deadline
+        ] = true;
+
         _finalizeSignedSale(
             nftContract,
             tokenId,
             paymentErc20TokenAddress,
             seller,
-            price,
-            deadline
+            price
         );
     }
 
@@ -190,13 +193,16 @@ abstract contract EndemicSignedSale is
             revert InvalidSignature();
         }
 
+        signedSaleInvalidated[nftContract][tokenId][seller][msg.sender][price][
+            deadline
+        ] = true;
+
         _finalizeSignedSale(
             nftContract,
             tokenId,
             paymentErc20TokenAddress,
             seller,
-            price,
-            deadline
+            price
         );
     }
 
@@ -205,13 +211,8 @@ abstract contract EndemicSignedSale is
         uint256 tokenId,
         address paymentErc20TokenAddress,
         address payable seller,
-        uint256 price,
-        uint256 deadline
+        uint256 price
     ) internal {
-        signedSaleInvalidated[nftContract][tokenId][seller][msg.sender][price][
-            deadline
-        ] = true;
-
         (
             uint256 makerCut,
             ,

--- a/contracts/exchange/mixins/EndemicSignedSale.sol
+++ b/contracts/exchange/mixins/EndemicSignedSale.sol
@@ -99,28 +99,18 @@ abstract contract EndemicSignedSale is
             revert InvalidSignedSale();
         }
 
-        bytes32 digest = keccak256(
-            abi.encodePacked(
-                "\x19\x01",
-                DOMAIN_SEPARATOR,
-                keccak256(
-                    abi.encode(
-                        SIGNED_SALE_TYPEHASH,
-                        nftContract,
-                        tokenId,
-                        paymentErc20TokenAddress,
-                        seller,
-                        address(0),
-                        price,
-                        deadline
-                    )
-                )
-            )
+        _verifySignature(
+            nftContract,
+            tokenId,
+            paymentErc20TokenAddress,
+            seller,
+            address(0),
+            price,
+            deadline,
+            v,
+            r,
+            s
         );
-
-        if (ecrecover(digest, v, r, s) != seller) {
-            revert InvalidSignature();
-        }
 
         signedSaleInvalidated[nftContract][tokenId][seller][address(0)][price][
             deadline
@@ -170,28 +160,18 @@ abstract contract EndemicSignedSale is
             revert InvalidSignedSale();
         }
 
-        bytes32 digest = keccak256(
-            abi.encodePacked(
-                "\x19\x01",
-                DOMAIN_SEPARATOR,
-                keccak256(
-                    abi.encode(
-                        SIGNED_SALE_TYPEHASH,
-                        nftContract,
-                        tokenId,
-                        paymentErc20TokenAddress,
-                        seller,
-                        buyer,
-                        price,
-                        deadline
-                    )
-                )
-            )
+        _verifySignature(
+            nftContract,
+            tokenId,
+            paymentErc20TokenAddress,
+            seller,
+            buyer,
+            price,
+            deadline,
+            v,
+            r,
+            s
         );
-
-        if (ecrecover(digest, v, r, s) != seller) {
-            revert InvalidSignature();
-        }
 
         signedSaleInvalidated[nftContract][tokenId][seller][msg.sender][price][
             deadline
@@ -248,6 +228,42 @@ abstract contract EndemicSignedSale is
             totalCut,
             paymentErc20TokenAddress
         );
+    }
+
+    function _verifySignature(
+        address nftContract,
+        uint256 tokenId,
+        address paymentErc20TokenAddress,
+        address seller,
+        address buyer,
+        uint256 price,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) internal view {
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                DOMAIN_SEPARATOR,
+                keccak256(
+                    abi.encode(
+                        SIGNED_SALE_TYPEHASH,
+                        nftContract,
+                        tokenId,
+                        paymentErc20TokenAddress,
+                        seller,
+                        buyer,
+                        price,
+                        deadline
+                    )
+                )
+            )
+        );
+
+        if (ecrecover(digest, v, r, s) != seller) {
+            revert InvalidSignature();
+        }
     }
 
     /**

--- a/test/exchange/EndemicSignedSale.js
+++ b/test/exchange/EndemicSignedSale.js
@@ -16,12 +16,12 @@ const { addTakerFee } = require('../helpers/token');
 const INVALID_SIGNATURE = 'InvalidSignature';
 const INVALID_PAYMENT_METHOD = 'InvalidPaymentMethod';
 
-const PRIVATE_SALE_EXPIRED = 'PrivateSaleExpired';
-const PRIVATE_SALE_SUCCESS = 'PrivateSaleSuccess';
+const SIGNED_SALE_EXPIRED = 'SignedSaleExpired';
+const SIGNED_SALE_SUCCESS = 'SignedSaleSuccess';
 
 const UNSUFFICIENT_CURRENCY_SUPPLIED = 'UnsufficientCurrencySupplied';
 
-describe('EndemicPrivateSale', () => {
+describe('EndemicSignedSale', () => {
   let endemicExchange, endemicToken, nftContract, paymentManagerContract;
 
   let owner, user2, mintApprover, collectionAdministrator;
@@ -65,7 +65,7 @@ describe('EndemicPrivateSale', () => {
     await mintToken(owner.address);
   }
 
-  const getSignedPrivateSale = async (paymentErc20TokenAddress, buyer) => {
+  const getSignedSignedSale = async (paymentErc20TokenAddress, buyer) => {
     const wallet = ethers.Wallet.createRandom();
 
     const signer = wallet.connect(endemicExchange.provider);
@@ -96,16 +96,16 @@ describe('EndemicPrivateSale', () => {
     });
   };
 
-  const getPrivateSaleSignature = async ({
+  const getSignedSaleSignature = async ({
     paymentErc20TokenAddress = ZERO_ADDRESS,
     buyer = ZERO_ADDRESS,
   }) => {
-    const signedPrivateSale = await getSignedPrivateSale(
+    const signedSignedSale = await getSignedSignedSale(
       paymentErc20TokenAddress,
       buyer
     );
 
-    const signature = signedPrivateSale.substring(2);
+    const signature = signedSignedSale.substring(2);
     const r = '0x' + signature.substring(0, 64);
     const s = '0x' + signature.substring(64, 128);
     const v = parseInt(signature.substring(128, 130), 16);
@@ -121,12 +121,12 @@ describe('EndemicPrivateSale', () => {
     });
   });
 
-  describe('Buy from private sale with Ether', function () {
+  describe('Buy from signed sale with Ether', function () {
     beforeEach(deploy);
 
-    it('should fail with private sale expired', async function () {
+    it('should fail with signed sale expired', async function () {
       await expect(
-        endemicExchange.buyFromReservedPrivateSale(
+        endemicExchange.buyFromReservedSignedSale(
           ZERO_ADDRESS,
           nftContract.address,
           1,
@@ -136,12 +136,12 @@ describe('EndemicPrivateSale', () => {
           RANDOM_R_VALUE,
           RANDOM_S_VALUE
         )
-      ).to.be.revertedWithCustomError(endemicExchange, PRIVATE_SALE_EXPIRED);
+      ).to.be.revertedWithCustomError(endemicExchange, SIGNED_SALE_EXPIRED);
     });
 
     it('should fail with price not correct (too low provided)', async function () {
       await expect(
-        endemicExchange.buyFromReservedPrivateSale(
+        endemicExchange.buyFromReservedSignedSale(
           ZERO_ADDRESS,
           nftContract.address,
           1,
@@ -164,7 +164,7 @@ describe('EndemicPrivateSale', () => {
       const priceWithFees = addTakerFee(ONE_ETHER);
 
       await expect(
-        endemicExchange.buyFromReservedPrivateSale(
+        endemicExchange.buyFromReservedSignedSale(
           ZERO_ADDRESS,
           nftContract.address,
           1,
@@ -180,11 +180,11 @@ describe('EndemicPrivateSale', () => {
       ).to.be.revertedWithCustomError(endemicExchange, INVALID_SIGNATURE);
     });
 
-    it('should fail to buy from private sale when taker fee not included', async function () {
-      const { r, s, v } = await getPrivateSaleSignature({ buyer: owner });
+    it('should fail to buy from signed sale when taker fee not included', async function () {
+      const { r, s, v } = await getSignedSaleSignature({ buyer: owner });
 
       await expect(
-        endemicExchange.buyFromReservedPrivateSale(
+        endemicExchange.buyFromReservedSignedSale(
           ZERO_ADDRESS,
           nftContract.address,
           2,
@@ -203,13 +203,13 @@ describe('EndemicPrivateSale', () => {
       );
     });
 
-    it('should succesfully buy from private sale', async function () {
-      const { r, s, v } = await getPrivateSaleSignature({ buyer: owner });
+    it('should succesfully buy from signed sale', async function () {
+      const { r, s, v } = await getSignedSaleSignature({ buyer: owner });
 
       const priceWithFees = addTakerFee(ONE_ETHER);
 
       await expect(
-        endemicExchange.buyFromReservedPrivateSale(
+        endemicExchange.buyFromReservedSignedSale(
           ZERO_ADDRESS,
           nftContract.address,
           2,
@@ -222,18 +222,18 @@ describe('EndemicPrivateSale', () => {
             value: priceWithFees,
           }
         )
-      ).to.emit(endemicExchange, PRIVATE_SALE_SUCCESS);
+      ).to.emit(endemicExchange, SIGNED_SALE_SUCCESS);
 
       expect(await nftContract.ownerOf(2)).to.equal(owner.address);
     });
 
     it('should fail to buy with valid signature and invalid buyer', async function () {
-      const { r, s, v } = await getPrivateSaleSignature({ buyer: owner });
+      const { r, s, v } = await getSignedSaleSignature({ buyer: owner });
 
       await expect(
         endemicExchange
           .connect(user2)
-          .buyFromReservedPrivateSale(
+          .buyFromReservedSignedSale(
             ZERO_ADDRESS,
             nftContract.address,
             2,
@@ -250,7 +250,7 @@ describe('EndemicPrivateSale', () => {
     });
   });
 
-  describe('Buy from private sale with ERC20', function () {
+  describe('Buy from signed sale with ERC20', function () {
     beforeEach(async function () {
       await deploy();
 
@@ -262,9 +262,9 @@ describe('EndemicPrivateSale', () => {
       );
     });
 
-    it('should fail with private sale expired', async function () {
+    it('should fail with signed sale expired', async function () {
       await expect(
-        endemicExchange.buyFromReservedPrivateSale(
+        endemicExchange.buyFromReservedSignedSale(
           endemicToken.address,
           nftContract.address,
           1,
@@ -274,12 +274,12 @@ describe('EndemicPrivateSale', () => {
           RANDOM_R_VALUE,
           RANDOM_S_VALUE
         )
-      ).to.be.revertedWithCustomError(endemicExchange, PRIVATE_SALE_EXPIRED);
+      ).to.be.revertedWithCustomError(endemicExchange, SIGNED_SALE_EXPIRED);
     });
 
     it('should fail with Erc20 not supported', async function () {
       await expect(
-        endemicExchange.buyFromReservedPrivateSale(
+        endemicExchange.buyFromReservedSignedSale(
           '0x0000000000000000000000000000000000000001',
           nftContract.address,
           1,
@@ -294,7 +294,7 @@ describe('EndemicPrivateSale', () => {
 
     it('should fail with price not correct (too low approved)', async function () {
       await expect(
-        endemicExchange.buyFromReservedPrivateSale(
+        endemicExchange.buyFromReservedSignedSale(
           endemicToken.address,
           nftContract.address,
           1,
@@ -322,7 +322,7 @@ describe('EndemicPrivateSale', () => {
       await expect(
         endemicExchange
           .connect(user2)
-          .buyFromReservedPrivateSale(
+          .buyFromReservedSignedSale(
             endemicToken.address,
             nftContract.address,
             1,
@@ -335,8 +335,8 @@ describe('EndemicPrivateSale', () => {
       ).to.be.revertedWithCustomError(endemicExchange, INVALID_SIGNATURE);
     });
 
-    it('should fail to buy from private sale when taker fee not included', async function () {
-      const { r, s, v } = await getPrivateSaleSignature({ buyer: owner });
+    it('should fail to buy from signed sale when taker fee not included', async function () {
+      const { r, s, v } = await getSignedSaleSignature({ buyer: owner });
 
       await endemicToken.transfer(user2.address, ONE_ETHER);
 
@@ -347,7 +347,7 @@ describe('EndemicPrivateSale', () => {
       await expect(
         endemicExchange
           .connect(user2)
-          .buyFromReservedPrivateSale(
+          .buyFromReservedSignedSale(
             endemicToken.address,
             nftContract.address,
             2,
@@ -363,8 +363,8 @@ describe('EndemicPrivateSale', () => {
       );
     });
 
-    it('should succesfully buy from private sale', async function () {
-      const { r, s, v } = await getPrivateSaleSignature({
+    it('should succesfully buy from signed sale', async function () {
+      const { r, s, v } = await getSignedSaleSignature({
         paymentErc20TokenAddress: endemicToken.address,
         buyer: owner,
       });
@@ -374,7 +374,7 @@ describe('EndemicPrivateSale', () => {
       await endemicToken.approve(endemicExchange.address, priceWithFees);
 
       await expect(
-        endemicExchange.buyFromReservedPrivateSale(
+        endemicExchange.buyFromReservedSignedSale(
           endemicToken.address,
           nftContract.address,
           2,
@@ -384,13 +384,13 @@ describe('EndemicPrivateSale', () => {
           r,
           s
         )
-      ).to.emit(endemicExchange, PRIVATE_SALE_SUCCESS);
+      ).to.emit(endemicExchange, SIGNED_SALE_SUCCESS);
 
       expect(await nftContract.ownerOf(2)).to.equal(owner.address);
     });
 
     it('should fail to buy with valid signature and invalid buyer', async function () {
-      const { r, s, v } = await getPrivateSaleSignature({
+      const { r, s, v } = await getSignedSaleSignature({
         paymentErc20TokenAddress: endemicToken.address,
         buyer: owner,
       });
@@ -401,7 +401,7 @@ describe('EndemicPrivateSale', () => {
       await expect(
         endemicExchange
           .connect(user2)
-          .buyFromReservedPrivateSale(
+          .buyFromReservedSignedSale(
             endemicToken.address,
             nftContract.address,
             2,

--- a/test/exchange/EndemicSignedSale.js
+++ b/test/exchange/EndemicSignedSale.js
@@ -65,7 +65,7 @@ describe('EndemicSignedSale', () => {
     await mintToken(owner.address);
   }
 
-  const getSignedSignedSale = async (paymentErc20TokenAddress, buyer) => {
+  const getSignedSale = async (paymentErc20TokenAddress, buyer) => {
     const wallet = ethers.Wallet.createRandom();
 
     const signer = wallet.connect(endemicExchange.provider);
@@ -100,12 +100,12 @@ describe('EndemicSignedSale', () => {
     paymentErc20TokenAddress = ZERO_ADDRESS,
     buyer = ZERO_ADDRESS,
   }) => {
-    const signedSignedSale = await getSignedSignedSale(
+    const signedSale = await getSignedSale(
       paymentErc20TokenAddress,
       buyer
     );
 
-    const signature = signedSignedSale.substring(2);
+    const signature = signedSale.substring(2);
     const r = '0x' + signature.substring(0, 64);
     const s = '0x' + signature.substring(64, 128);
     const v = parseInt(signature.substring(128, 130), 16);

--- a/test/helpers/eip712.js
+++ b/test/helpers/eip712.js
@@ -21,7 +21,7 @@ const getTypedMessage = ({
         { name: 'verifyingContract', type: 'address' },
         { name: 'salt', type: 'bytes32' },
       ],
-      PrivateSale: [
+      SignedSale: [
         { name: 'nftContract', type: 'address' },
         { name: 'tokenId', type: 'uint256' },
         { name: 'paymentErc20TokenAddress', type: 'address' },
@@ -31,7 +31,7 @@ const getTypedMessage = ({
         { name: 'deadline', type: 'uint256' },
       ],
     },
-    primaryType: 'PrivateSale',
+    primaryType: 'SignedSale',
     domain: {
       name: 'Endemic Exchange',
       version: '1',


### PR DESCRIPTION
- Prijasnja funkcija `buyFromPrivateSale` se sad zove `buyFromReservedSignedSale`. 
- Dodana je nova funkcija `buyFromSignedSale`, seller potpisuje poruku koja sadrzi null adresu umisto neke specificne adrese tako da token moze kupit bilo tko.